### PR TITLE
Handle Mapbox token via config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.js

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # Mapbox
+
+## Mapbox Token Setup
+
+The frontend reads the Mapbox access token from a `config.js` file located in the project root. This file is ignored by git so that your token is not committed.
+
+Create the file by copying `config.example.js` or by using the provided script:
+
+```bash
+# Option 1: copy the example and edit
+cp config.example.js config.js
+# then replace <YOUR_MAPBOX_TOKEN> with your token
+
+# Option 2: generate from environment variable
+MAPBOX_TOKEN=<your_token> node generate-config.js
+```
+
+After `config.js` is created, start the local server with:
+
+```bash
+python Server.py
+```

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,3 @@
+window.config = {
+    MAPBOX_TOKEN: '<YOUR_MAPBOX_TOKEN>'
+};

--- a/generate-config.js
+++ b/generate-config.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const token = process.env.MAPBOX_TOKEN;
+
+if (!token) {
+  console.error('MAPBOX_TOKEN environment variable is not set.');
+  process.exit(1);
+}
+
+fs.writeFileSync('config.js', `window.config = {\n    MAPBOX_TOKEN: '${token}'\n};\n`);
+console.log('config.js generated');

--- a/index.html
+++ b/index.html
@@ -33,8 +33,10 @@
     </div>
     <div id="map"></div>
 
+    <!-- Token configuration -->
+    <script src="config.js"></script>
     <script>
-        mapboxgl.accessToken = 'pk.eyJ1Ijoic3ZlbndpbmtsZXJidm13IiwiYSI6ImNtN3lra2pmYTA5YnkybHNqZ2ZuYTQ3enAifQ.IPWqBFTpyQekDYCLJIpXqQ';
+        mapboxgl.accessToken = window.config.MAPBOX_TOKEN;
 
         const bundeslaender = [
             {id: '01', name: 'Schleswig-Holstein'},


### PR DESCRIPTION
## Summary
- load the Mapbox access token from `config.js`
- provide `config.example.js` and generator script
- document how to supply the token in the README
- ignore `config.js` in git

## Testing
- `MAPBOX_TOKEN=testtoken node generate-config.js`