### PR TITLE
Fix Salesforce env variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ from Salesforce.
    ```
 3. Set the Salesforce credentials as environment variables:
    ```bash
-   export SF_USERNAME=your_username
-   export SF_PASSWORD=your_password
-   export SF_SECURITY_TOKEN=your_token
+   export SALESFORCE_USERNAME=your_username
+   export SALESFORCE_PASSWORD=your_password
+   export SALESFORCE_SECURITY_TOKEN=your_token
    ```
 4. Ensure `Landkreise.geojson` and `Wirtschaftsregionen_cleaned.geojson` are in
    the project directory. If they are hosted elsewhere download them first.

--- a/backend/salesforce_api.py
+++ b/backend/salesforce_api.py
@@ -27,9 +27,9 @@ def connect_salesforce():
 
     try:
         sf = Salesforce(
-            username=os.environ.get("SF_USERNAME"),
-            password=os.environ.get("SF_PASSWORD"),
-            security_token=os.environ.get("SF_SECURITY_TOKEN")
+            username=username,
+            password=password,
+            security_token=security_token
         )
         logging.info("✅ Verbindung zu Salesforce erfolgreich.")
         return sf


### PR DESCRIPTION
## Summary
- fix credentials usage in `salesforce_api.py`
- update README examples to use `SALESFORCE_*` variables

## Testing
- `python -m py_compile backend/salesforce_api.py Server.py generate-config.js`