### PR TITLE
Fix object name in Salesforce query

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mapbox Demo
 
-This repository contains a small Mapbox demo showing German regions with data retrieved from Salesforce. The map now also shows which employees are active in each county based on records from the custom object `Zuordnung_BV_auf_Landkreis__c`. In addition it displays how many companies exist in each district using data from `Potenziale_Landkreise__c`.
+This repository contains a small Mapbox demo showing German regions with data retrieved from Salesforce. The map now also shows which employees are active in each county based on records from the custom object `Zuordnung_BV_auf_Landkreis__c`. In addition it displays how many companies exist in each district using data from `Potenziale_Lankreise__c`.
 
 ## License
 

--- a/backend/salesforce_api.py
+++ b/backend/salesforce_api.py
@@ -152,7 +152,7 @@ def get_unternehmen_by_landkreis():
 
     query = """
         SELECT Landkreis_Nummer__c, Insgesamt_WZ2008_Abschnitte_B_NP_S__c
-        FROM Potenziale_Landkreise__c
+        FROM Potenziale_Lankreise__c
         WHERE Landkreis_Nummer__c != NULL
     """
 


### PR DESCRIPTION
## Summary
- use `Potenziale_Lankreise__c` in the Salesforce SOQL query
- document the correct object name in README

## Testing
- `python -m py_compile backend/salesforce_api.py`