### PR TITLE
Add employee-based district coloring toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ This project is licensed under the [MIT License](LICENSE).
 3. Open [http://localhost:8000/index.html](http://localhost:8000/index.html) in your browser to view the map.
 4. The backend exposes `/mitarbeiter_by_landkreis` which the map uses to display the employees active in each county when hovering over a district.
 5. The endpoint `/unternehmen_by_landkreis` provides the total number of companies per district, which is also shown in the hover popup.
+6. Use the checkbox "nach Mitarbeitern" in the control panel to toggle coloring of counties based on the number of assigned employees.

--- a/index.html
+++ b/index.html
@@ -30,6 +30,8 @@
         <div id="region-list"></div>
         <h3>Bundesländer filtern</h3>
         <select id="bundesland-select"></select>
+        <h3>Landkreise einfärben</h3>
+        <label><input type="checkbox" id="color-toggle" checked> nach Mitarbeitern</label>
     </div>
     <div id="map"></div>
 
@@ -68,6 +70,7 @@
         let accountsData = {};
         let mitarbeiterData = {};
         let potenzialeData = {};
+        let coloringEnabled = true;
 
         map.on('load', function () {
             fetch('http://localhost:8000/Wirtschaftsregionen_cleaned.geojson')
@@ -115,7 +118,7 @@
                 id: 'landkreise-fill',
                 type: 'fill',
                 source: 'landkreise',
-                paint: { 'fill-color': '#FF5733', 'fill-opacity': 0 }
+                paint: { 'fill-color': '#FFFFFF', 'fill-opacity': 0 }
             });
 
             map.addLayer({
@@ -126,6 +129,12 @@
             });
 
             const bundeslandSelect = document.getElementById('bundesland-select');
+            const colorToggle = document.getElementById('color-toggle');
+            coloringEnabled = colorToggle.checked;
+            colorToggle.addEventListener('change', () => {
+                coloringEnabled = colorToggle.checked;
+                updateLandkreisColors();
+            });
             const alleOption = document.createElement('option');
             alleOption.value = 'all';
             alleOption.textContent = 'Alle';
@@ -149,6 +158,7 @@
                     map.setFilter('landkreise-layer', ['==', ['get', 'SN_L'], selectedId]);
                     map.setFilter('landkreise-fill', ['==', ['get', 'SN_L'], selectedId]);
                 }
+                updateLandkreisColors();
             }
             updateBundeslaenderFilter();
 
@@ -158,11 +168,31 @@
 
             fetch('http://127.0.0.1:5000/mitarbeiter_by_landkreis')
                 .then(res => res.json())
-                .then(data => { mitarbeiterData = data; });
+                .then(data => { mitarbeiterData = data; updateLandkreisColors(); });
 
             fetch('http://127.0.0.1:5000/unternehmen_by_landkreis')
                 .then(res => res.json())
                 .then(data => { potenzialeData = data; });
+
+            function updateLandkreisColors() {
+                if (!coloringEnabled) {
+                    map.setPaintProperty('landkreise-fill', 'fill-opacity', 0);
+                    return;
+                }
+
+                const expression = ['match', ['get', 'RS']];
+                for (const [code, staff] of Object.entries(mitarbeiterData)) {
+                    const count = Array.isArray(staff) ? staff.length : 0;
+                    let color = '#FFFFFF';
+                    if (count === 1) color = '#008000';
+                    else if (count === 2) color = '#FFFF00';
+                    else if (count > 2) color = '#FF0000';
+                    expression.push(code, color);
+                }
+                expression.push('#FFFFFF');
+                map.setPaintProperty('landkreise-fill', 'fill-color', expression);
+                map.setPaintProperty('landkreise-fill', 'fill-opacity', 0.6);
+            }
 
             map.on('mousemove', 'landkreise-fill', (e) => {
                 const districtName = e.features[0].properties.GEN;


### PR DESCRIPTION
## Summary
- enable toggling district coloring based on employee counts
- describe new feature in README

## Testing
- `python -m py_compile backend/salesforce_api.py Server.py`

------
https://chatgpt.com/codex/tasks/task_b_6849621c8c548323beda69b8ccb73140