### PR TITLE
Make demo accessible on LAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,15 @@ database location or name.
    ```bash
    python Server.py
    ```
-2. In a separate terminal start the Flask backend that connects to Salesforce:
+2. In a separate terminal start the Flask backend that connects to Salesforce.
+   It now listens on all interfaces so it can be reached from other machines:
    ```bash
    python backend/salesforce_api.py
    ```
 3. Open [http://localhost:8000/index.html](http://localhost:8000/index.html) in your browser to view the map.
+   To access the map from another computer on the same network, replace
+   `localhost` with the IP address of the machine running the server,
+   e.g. `http://192.168.0.10:8000/index.html`.
 4. The backend exposes `/mitarbeiter_by_landkreis` which the map uses to display the employees active in each county when hovering over a district.
 5. The endpoint `/unternehmen_by_landkreis` provides the total number of companies per district, which is also shown in the hover popup.
 6. Two additional endpoints handle county assignments:

--- a/backend/salesforce_api.py
+++ b/backend/salesforce_api.py
@@ -223,5 +223,6 @@ def post_assignment():
     return jsonify({"status": "ok"})
 
 if __name__ == '__main__':
-    app.run(debug=True, port=5000)
+    # Listen on all interfaces so the API can be reached from other machines
+    app.run(host='0.0.0.0', debug=True, port=5000)
 

--- a/index.html
+++ b/index.html
@@ -58,6 +58,8 @@
     <script src="config.js"></script>
     <script>
         mapboxgl.accessToken = window.config.MAPBOX_TOKEN;
+        // Use the same host as the page for API requests so remote clients work
+        const apiBase = 'http://' + window.location.hostname + ':5000';
 
         const bundeslaender = [
             {id: '01', name: 'Schleswig-Holstein'},
@@ -103,7 +105,7 @@
         });
 
         map.on('load', function () {
-            fetch('http://localhost:8000/Wirtschaftsregionen_cleaned.geojson')
+            fetch('./Wirtschaftsregionen_cleaned.geojson')
                 .then(response => response.json())
                 .then(data => {
                     map.addSource('wirtschaftsregionen', { type: 'geojson', data: data });
@@ -142,7 +144,7 @@
                     });
                 });
 
-            map.addSource('landkreise', { type: 'geojson', data: 'http://localhost:8000/Landkreise.geojson' });
+            map.addSource('landkreise', { type: 'geojson', data: './Landkreise.geojson' });
 
             map.addLayer({
                 id: 'landkreise-fill',
@@ -192,15 +194,15 @@
             }
             updateBundeslaenderFilter();
 
-            fetch('http://127.0.0.1:5000/accounts_by_landkreis')
+            fetch(`${apiBase}/accounts_by_landkreis`)
                 .then(res => res.json())
                 .then(data => { accountsData = data; });
 
-            fetch('http://127.0.0.1:5000/mitarbeiter_by_landkreis')
+            fetch(`${apiBase}/mitarbeiter_by_landkreis`)
                 .then(res => res.json())
                 .then(data => { mitarbeiterData = data; updateLandkreisColors(); });
 
-            fetch('http://127.0.0.1:5000/unternehmen_by_landkreis')
+            fetch(`${apiBase}/unternehmen_by_landkreis`)
                 .then(res => res.json())
                 .then(data => { potenzialeData = data; });
 
@@ -256,7 +258,7 @@
                 const count = accountsData[districtNumber] || 0;
                 const totalCompanies = potenzialeData[districtNumber] || 0;
 
-                fetch(`http://127.0.0.1:5000/assignment/${districtNumber}`)
+                fetch(`${apiBase}/assignment/${districtNumber}`)
                     .then(res => res.json())
                     .then(assign => {
                         const wrVal = assign.wirtschaftsregion || '';
@@ -286,7 +288,7 @@
                             const wrInput = document.getElementById('wr-neu');
                             const wr = wrInput ? wrInput.value : '';
                             const fkts = Array.from(document.querySelectorAll('#fkt-container .fkt-input')).map(el => el.value);
-                            fetch('http://127.0.0.1:5000/assignment', {
+                            fetch(`${apiBase}/assignment`, {
                                 method: 'POST',
                                 headers: {'Content-Type': 'application/json'},
                                 body: JSON.stringify({ rs: districtNumber, wirtschaftsregion: wr, fkt: fkts })


### PR DESCRIPTION
## Summary
- load GeoJSON files using relative URLs so they work from remote devices
- update README with instructions to open the site via server IP address
- run backend on all interfaces and use current host for API requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68501eec13908323aa7c28021c13567d