### PR TITLE
Use ThreadingHTTPServer in server

### DIFF
--- a/Server.py
+++ b/Server.py
@@ -18,6 +18,7 @@ class GeoJSONCORSRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         super().end_headers()
 
-with socketserver.TCPServer(("", PORT), GeoJSONCORSRequestHandler) as httpd:
+# Use ThreadingHTTPServer to handle multiple requests concurrently
+with http.server.ThreadingHTTPServer(("", PORT), GeoJSONCORSRequestHandler) as httpd:
     print(f"✅ Lokaler Server läuft auf http://localhost:{PORT}")
     httpd.serve_forever()


### PR DESCRIPTION
## Summary
- use `http.server.ThreadingHTTPServer` to allow multiple concurrent connections
- keep the message about the listening port

## Testing
- `python3 -m py_compile Server.py`

------
https://chatgpt.com/codex/tasks/task_b_685047569f5c8323ab85fc3875fcbe07