### PR TITLE
Fix protocol for API base URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
     <script>
         mapboxgl.accessToken = window.config.MAPBOX_TOKEN;
         // Use the same host as the page for API requests so remote clients work
-        const apiBase = 'http://' + window.location.hostname + ':5000';
+        const apiBase = `${window.location.protocol}//${window.location.hostname}:5000`;
 
         const bundeslaender = [
             {id: '01', name: 'Schleswig-Holstein'},


### PR DESCRIPTION
## Summary
- match API calls to current page protocol

## Testing
- `python -m py_compile Server.py`


------
https://chatgpt.com/codex/tasks/task_b_68504872ede88323a30accd0733970b2