### PR TITLE
Persist completed districts color

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ database location or name.
    e.g. `http://192.168.0.10:8000/index.html`.
 4. The backend exposes `/mitarbeiter_by_landkreis` which the map uses to display the employees active in each county when hovering over a district.
 5. The endpoint `/unternehmen_by_landkreis` provides the total number of companies per district, which is also shown in the hover popup.
-6. Two additional endpoints handle county assignments:
+6. Endpoints handling county assignments:
    - `POST /assignment` stores an assignment record.
    - `GET /assignment/<rs>` retrieves the stored data for a county.
+   - `GET /assignments` returns a list of all saved county numbers.
 7. Use the dropdown "Ansicht" to switch between **Ist** and **Soll**.
    In **Soll** view, clicking a county opens an info box where you can edit
    the economic region and FKT contacts. The assignments are saved in the

--- a/backend/salesforce_api.py
+++ b/backend/salesforce_api.py
@@ -205,6 +205,15 @@ def get_assignment(rs):
     )
 
 
+@app.route('/assignments', methods=['GET'])
+@cross_origin()
+def get_assignments():
+    """Return a dict of all district codes that have an assignment."""
+    cur = db_conn.execute("SELECT rs FROM assignments")
+    data = {row["rs"]: True for row in cur.fetchall()}
+    return jsonify(data)
+
+
 @app.route('/assignment', methods=['POST'])
 @cross_origin()
 def post_assignment():

--- a/index.html
+++ b/index.html
@@ -219,6 +219,10 @@
                 .then(res => res.json())
                 .then(data => { potenzialeData = data; });
 
+            fetch(`${apiBase}/assignments`)
+                .then(res => res.json())
+                .then(data => { assignmentData = data; updateLandkreisColors(); });
+
             function updateLandkreisColors() {
                 if (!coloringEnabled) {
                     map.setPaintProperty('landkreise-fill', 'fill-opacity', 0);


### PR DESCRIPTION
## Summary
- add `GET /assignments` endpoint to return saved district numbers
- load assignments on page load so completed districts stay blue
- document new endpoint in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6850682e2574832381b52b8aea70cbf0