### PR TITLE
Default economic regions hidden

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,7 @@
                             id: `region-${region}`,
                             type: 'fill',
                             source: 'wirtschaftsregionen',
+                            layout: { visibility: 'none' },
                             paint: { 'fill-color': '#088', 'fill-opacity': 0.5 },
                             filter: ['==', ['get', 'Wirtschaftsregion'], region]
                         });
@@ -139,7 +140,7 @@
                         const checkbox = document.createElement('input');
                         checkbox.type = 'checkbox';
                         checkbox.id = `checkbox-${region}`;
-                        checkbox.checked = true;
+                        checkbox.checked = false;
 
                         checkbox.addEventListener('change', () => {
                             const visibility = checkbox.checked ? 'visible' : 'none';


### PR DESCRIPTION
## Summary
- ensure economic regions start hidden on load

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68512588264c83238c042f2670e685e7