### PR TITLE
Fix map color toggle behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,11 +226,7 @@
                 .then(data => { assignmentData = data; updateLandkreisColors(); });
 
             function updateLandkreisColors() {
-                if (!coloringEnabled) {
-                    map.setPaintProperty('landkreise-fill', 'fill-opacity', 0);
-                    return;
-                }
-
+                const showColors = coloringEnabled || sollView;
                 const expression = ['match', ['get', 'RS']];
 
                 if (sollView) {
@@ -239,19 +235,21 @@
                     }
                 }
 
-                for (const [code, staff] of Object.entries(mitarbeiterData)) {
-                    if (sollView && assignmentData[code]) continue;
-                    const count = Array.isArray(staff) ? staff.length : 0;
-                    let color = '#FFFFFF';
-                    if (count === 1) color = '#008000';
-                    else if (count === 2) color = '#FFFF00';
-                    else if (count > 2) color = '#FF0000';
-                    expression.push(code, color);
+                if (coloringEnabled) {
+                    for (const [code, staff] of Object.entries(mitarbeiterData)) {
+                        if (sollView && assignmentData[code]) continue;
+                        const count = Array.isArray(staff) ? staff.length : 0;
+                        let color = '#FFFFFF';
+                        if (count === 1) color = '#008000';
+                        else if (count === 2) color = '#FFFF00';
+                        else if (count > 2) color = '#FF0000';
+                        expression.push(code, color);
+                    }
                 }
 
                 expression.push('#FFFFFF');
                 map.setPaintProperty('landkreise-fill', 'fill-color', expression);
-                map.setPaintProperty('landkreise-fill', 'fill-opacity', 0.6);
+                map.setPaintProperty('landkreise-fill', 'fill-opacity', showColors ? 0.6 : 0);
             }
 
             map.on('mousemove', 'landkreise-fill', (e) => {


### PR DESCRIPTION
## Summary
- keep blue highlights in Soll view even with "nach Mitarbeitern" disabled
- suppress colors only when both view is Ist and coloring is disabled
- set fill opacity to 0.6 whenever any coloring is shown

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_b_68512bc2594483238d42682228961dcd