### PR TITLE
Handle removal of assignments

### DIFF
--- a/backend/salesforce_api.py
+++ b/backend/salesforce_api.py
@@ -221,15 +221,19 @@ def post_assignment():
     data = request.get_json(force=True)
     rs = data.get("rs")
     region = data.get("wirtschaftsregion")
-    fkt_list = data.get("fkt", [])
+    fkt_list = [f.strip() for f in data.get("fkt", []) if str(f).strip()]
     if not rs:
         return jsonify({"error": "rs missing"}), 400
+    if not fkt_list:
+        db_conn.execute("DELETE FROM assignments WHERE rs=?", (rs,))
+        db_conn.commit()
+        return jsonify({"status": "deleted"})
     db_conn.execute(
         "INSERT OR REPLACE INTO assignments(rs, wirtschaftsregion, fkt) VALUES (?, ?, ?)",
         (rs, region, json.dumps(fkt_list)),
     )
     db_conn.commit()
-    return jsonify({"status": "ok"})
+    return jsonify({"status": "saved"})
 
 if __name__ == '__main__':
     # Listen on all interfaces so the API can be reached from other machines

--- a/index.html
+++ b/index.html
@@ -312,16 +312,24 @@
                         document.getElementById('save-info').onclick = () => {
                             const wrInput = document.getElementById('wr-neu');
                             const wr = wrInput ? wrInput.value : '';
-                            const fkts = Array.from(document.querySelectorAll('#fkt-container .fkt-input')).map(el => el.value);
+                            const fkts = Array.from(document.querySelectorAll('#fkt-container .fkt-input'))
+                                .map(el => el.value.trim())
+                                .filter(val => val !== '');
                             fetch(`${apiBase}/assignment`, {
                                 method: 'POST',
                                 headers: {'Content-Type': 'application/json'},
                                 body: JSON.stringify({ rs: districtNumber, wirtschaftsregion: wr, fkt: fkts })
-                            }).then(() => {
-                                infoBox.style.display = 'none';
-                                assignmentData[districtNumber] = true;
-                                updateLandkreisColors();
                             })
+                              .then(res => res.json())
+                              .then(res => {
+                                  infoBox.style.display = 'none';
+                                  if (res.status === 'deleted') {
+                                      delete assignmentData[districtNumber];
+                                  } else {
+                                      assignmentData[districtNumber] = true;
+                                  }
+                                  updateLandkreisColors();
+                              })
                               .catch(err => console.error(err));
                         };
                     });


### PR DESCRIPTION
## Summary
- clean empty FKT values on save
- delete empty assignments on the server
- handle deleted status in the frontend

## Testing
- `python -m py_compile backend/salesforce_api.py backend/db.py`

------
https://chatgpt.com/codex/tasks/task_b_68512e6da370832389a0e90f29f2878e