### PR TITLE
Add AutoTable-based PDF export

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <script src="https://api.mapbox.com/mapbox-gl-js/v2.9.1/mapbox-gl.js"></script>
     <link href="https://api.mapbox.com/mapbox-gl-js/v2.9.1/mapbox-gl.css" rel="stylesheet">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js"></script>
     <style>
         body { margin: 0; padding: 0; }
         #map { width: 100%; height: 100vh; }
@@ -424,6 +425,24 @@
                 const pdfWidth = pdf.internal.pageSize.getWidth();
                 const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
                 pdf.addImage(dataUrl, 'PNG', 0, 0, pdfWidth, pdfHeight);
+                if (wrSelect.value) {
+                    const region = wrSelect.value;
+                    pdf.addPage();
+                    pdf.text(`Die ausgew\u00E4hlte Wirtschaftsregion NEU: ${region}`, 10, 10);
+                    const rows = assignmentsFull
+                        .filter(a => a.wirtschaftsregion === region)
+                        .map(a => {
+                            const lkFeature = landkreiseData.features.find(f => f.properties.RS === a.rs);
+                            const lkName = lkFeature ? lkFeature.properties.GEN : a.rs;
+                            const mitglieder = accountsData[a.rs] || 0;
+                            const potenzial = potenzialeData[a.rs] || 0;
+                            return [a.fkt.join(', '), lkName, mitglieder, potenzial];
+                        });
+                    pdf.autoTable({
+                        head: [['Zust\u00E4ndiger FKT Neu', 'Landkreis', 'Mitglieder', 'Unternehmenspotenzial']],
+                        body: rows
+                    });
+                }
                 pdf.save('karte.pdf');
             } else {
                 const link = document.createElement('a');


### PR DESCRIPTION
## Summary
- include jsPDF AutoTable plugin
- enhance `exportMap` to add assignment table for selected region when exporting to PDF

## Testing
- `python -m py_compile Server.py backend/salesforce_api.py`

------
https://chatgpt.com/codex/tasks/task_b_6852a478330483239f8c0d7f7483b359